### PR TITLE
Don't convert longs to int when producing MUInt32

### DIFF
--- a/shared/src/main/scala/scodec/msgpack/Serialize.scala
+++ b/shared/src/main/scala/scodec/msgpack/Serialize.scala
@@ -92,7 +92,7 @@ object Serialize {
           else MUInt16(v.toInt)
         }
         else {
-          if (v < (1L << 32)) MUInt32(v.toInt)
+          if (v < (1L << 32)) MUInt32(v)
           else MUInt64(v)
         }
       })


### PR DESCRIPTION
Longs between `1L << 31` and `1L << 32` were being converted to Int before being encoded as a `MUInt32`. Since numbers in that range have a 1 in the 31st bit position, they present as negative numbers when converted to ints, and negative values are not allowed in `MUInt32`. `MUInt32` accepts a long, so we can simply pass the value in hand with no conversion.

Fixes #12